### PR TITLE
In Inflection.convertKeysTo{Snake,Camel}Case, preserve arrays

### DIFF
--- a/lib/monarch/util/inflection.coffee
+++ b/lib/monarch/util/inflection.coffee
@@ -129,13 +129,16 @@ Monarch.Util.Inflection =
   convertKeysToSnakeCase: (data) ->
     convertedData = {}
     for key, value of data
-      value = Monarch.Util.Inflection.convertKeysToSnakeCase(value) if _.isObject(value)
+      value = Monarch.Util.Inflection.convertKeysToSnakeCase(value) if isHash(value)
       convertedData[Monarch.Util.Inflection.underscore(key)] = value
     convertedData
 
   convertKeysToCamelCase: (data) ->
     convertedData = {}
     for key, value of data
-      value = Monarch.Util.Inflection.convertKeysToCamelCase(value) if _.isObject(value)
+      value = Monarch.Util.Inflection.convertKeysToCamelCase(value) if isHash(value)
       convertedData[Monarch.Util.Inflection.camelize(key, true)] = value
     convertedData
+
+isHash = (obj) ->
+  _.isObject(obj) and not _.isArray(obj)


### PR DESCRIPTION
The methods `convertKeysToSnakeCase` and `convertKeysToCamelCase` were converting arrays into objects with numeric keys. I guess the new jasmine distinguishes between the two, so there were 2 specs failing. This fixes those tests.
